### PR TITLE
be more aggressive on logging and flushing.

### DIFF
--- a/tests/test_claim_db.py
+++ b/tests/test_claim_db.py
@@ -8,12 +8,12 @@ from lbryumx.model import ClaimInfo
 
 def test_claim_sequence_remove_reorders(block_processor):
     name, db = b'name', block_processor
-    db.put_claim_for_name(name, 'id1')
-    db.put_claim_for_name(name, 'id2')
-    db.put_claim_for_name(name, 'id3')
-    db.remove_claim_for_name(name, 'id2')
+    db.put_claim_for_name(name, b'id1')
+    db.put_claim_for_name(name, b'id2')
+    db.put_claim_for_name(name, b'id3')
+    db.remove_claim_for_name(name, b'id2')
 
-    assert db.get_claims_for_name(name) == {'id1': 1, 'id3': 2}
+    assert db.get_claims_for_name(name) == {b'id1': 1, b'id3': 2}
 
 
 def test_cert_to_claims_storage(block_processor):


### PR DESCRIPTION
During the last reorg sync failed due an assertion error. It's not possible currently to fix it as the user queries are being performed using the same methods that sync (#2). Once this is refactored, it can raise again. A comment was left in place for it.